### PR TITLE
Add badge, include more docstrings change dimension handling for computed variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # OceanRasterConversions.jl
 
-[![](https://img.shields.io/badge/docs-dev-blue.svg)](https://jbisits.github.io/OceanRasterConversions.jl/dev/)
+[![Doc dev badge](https://img.shields.io/badge/docs-dev-blue.svg)](https://jbisits.github.io/OceanRasterConversions.jl/dev/)
 [![Build Status](https://github.com/jbisits/OceanRasterConversions.jl/actions/workflows/CI.yml/badge.svg?branch=main)](https://github.com/jbisits/OceanRasterConversions.jl/actions/workflows/CI.yml?query=branch%3Amain)
 [![codecov](https://codecov.io/gh/jbisits/OceanRasterConversions.jl/branch/main/graph/badge.svg?token=XEAWB8IHFV)](https://codecov.io/gh/jbisits/OceanRasterConversions.jl)
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # OceanRasterConversions.jl
 
+[![](https://img.shields.io/badge/docs-dev-blue.svg)](https://jbisits.github.io/OceanRasterConversions.jl/dev/)
 [![Build Status](https://github.com/jbisits/OceanRasterConversions.jl/actions/workflows/CI.yml/badge.svg?branch=main)](https://github.com/jbisits/OceanRasterConversions.jl/actions/workflows/CI.yml?query=branch%3Amain)
 [![codecov](https://codecov.io/gh/jbisits/OceanRasterConversions.jl/branch/main/graph/badge.svg?token=XEAWB8IHFV)](https://codecov.io/gh/jbisits/OceanRasterConversions.jl)
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -65,4 +65,6 @@ convert_ocean_vars
 depth_to_pressure
 Sₚ_to_Sₐ
 θ_to_Θ
+in_situ_density
+potential_density
 ```

--- a/src/oceanconversions.jl
+++ b/src/oceanconversions.jl
@@ -173,21 +173,10 @@ absolute salinity (`Sₐ`), conservative temperature (`Θ`) and pressure (`p`).
 """
 function in_situ_density(Sₐ::Raster, Θ::Raster, p::Raster, find_nm::Raster)
 
-    rs_dims = dims(Sₐ)
     ρ = similar(Array(Sₐ))
+    @. ρ[find_nm] = GibbsSeaWater.gsw_rho(Sₐ[find_nm], Θ[find_nm], p[find_nm])
 
-    if isnothing(time)
-
-        @. ρ[find_nm] = GibbsSeaWater.gsw_rho(Sₐ[find_nm], Θ[find_nm], p[find_nm])
-        rs_dims = (lons, lats, z)
-
-    else
-
-        @. ρ[find_nm] = GibbsSeaWater.gsw_rho(Sₐ[find_nm], Θ[find_nm], p[find_nm])
-
-    end
-
-    return Raster(ρ, rs_dims)
+    return Raster(ρ, dims(Sₐ))
 
 end
 """
@@ -212,21 +201,10 @@ conservative temperature (`Θ`) and a user entered reference pressure (`p`).
 """
 function potential_density(Sₐ::Raster, Θ::Raster, p::Number, find_nm::Raster)
 
-    rs_dims = dims(Sₐ)
     σₚ = similar(Array(Sₐ))
+    @. σₚ[find_nm] = GibbsSeaWater.gsw_rho(Sₐ[find_nm], Θ[find_nm], p)
 
-    if isnothing(time)
-
-        @. σₚ[find_nm] = GibbsSeaWater.gsw_rho(Sₐ[find_nm], Θ[find_nm], p)
-        rs_dims = (lons, lats, z)
-
-    else
-
-        @. σₚ[find_nm] = GibbsSeaWater.gsw_rho(Sₐ[find_nm], Θ[find_nm], p)
-
-    end
-
-    return Raster(σₚ, rs_dims)
+    return Raster(σₚ, dims(Sₐ))
 
 end
 """

--- a/src/oceanconversions.jl
+++ b/src/oceanconversions.jl
@@ -29,9 +29,9 @@ function convert_ocean_vars(stack::RasterStack, var_names::NamedTuple;
     Sₐ = Sₚ_to_Sₐ(Sₚ, p, rs_dims, find_nm)
     Θ = θ_to_Θ(θ, Sₐ, rs_dims, find_nm)
     converted_vars = isnothing(ref_pressure) ?
-                (p = p, Sₐ = Sₐ, Θ = Θ, ρ = in_situ_density(Sₐ, Θ, p, rs_dims, find_nm)) :
+                (p = p, Sₐ = Sₐ, Θ = Θ, ρ = in_situ_density(Sₐ, Θ, p, find_nm)) :
                 (p = p, Sₐ = Sₐ, Θ = Θ,
-                 σₚ = potential_density(Sₐ, Θ, ref_pressure, rs_dims, find_nm))
+                 σₚ = potential_density(Sₐ, Θ, ref_pressure, find_nm))
 
     return RasterStack(converted_vars, rs_dims)
 
@@ -167,14 +167,14 @@ Convert the potential temperature, returning only the conservative temperature, 
 θ_to_Θ(series::RasterSeries, var_names::NamedTuple) = θ_to_Θ.(series, Ref(var_names))
 
 """
-    function in_situ_density(Sₐ::Raster, Θ::Raster, p::Raster, rs_dims::Tuple, find_nm::Raster)
-Compute in-situ density using `gsw_rho` from GibbsSeaWater.jl. This conversion depends on
+    function in_situ_density(Sₐ::Raster, Θ::Raster, p::Raster, find_nm::Raster)
+Compute in-situ density using `gsw_rho` from GibbsSeaWater.jl. This computation depends on
 absolute salinity (`Sₐ`), conservative temperature (`Θ`) and pressure (`p`).
 """
-function in_situ_density(Sₐ::Raster, Θ::Raster, p::Raster, rs_dims::Tuple, find_nm::Raster)
+function in_situ_density(Sₐ::Raster, Θ::Raster, p::Raster, find_nm::Raster)
 
-    lons, lats, z, time = rs_dims
-    ρ = similar(Array(Θ))
+    rs_dims = dims(Sₐ)
+    ρ = similar(Array(Sₐ))
 
     if isnothing(time)
 
@@ -196,24 +196,24 @@ end
 Compute and return the in-situ density `ρ` from a `RasterStack` or `RasterSeries`.
 This computation depends on absolute salinity `Sₐ`, conservative temperature `Θ`
 and pressure `p`. The variable names must be passed into the function as a `NamedTuple` in
-the form `(Sₐ = :salt_var, Θ = :temp_var, p = :pressure_var)`.
+the form `(Sₐ = :salt_var, Θ = :temp_var, p = :pressure_var)`. The returned `Raster` will
+have the same dimensions as `Rasterstack` that is passed in.
 """
 in_situ_density(stack::RasterStack, var_names::NamedTuple) =
     in_situ_density(stack[var_names.Sₐ], stack[var_names.Θ], stack[var_names.p],
-                    get_dims(stack[var_names.Sₐ]),
                    .!ismissing.(stack[var_names.Sₐ]) .&& .!ismissing.(stack[var_names.Θ]))
 in_situ_density(series::RasterSeries, var_names::NamedTuple) = in_situ_density.(series, Ref(var_names))
 
 """
-    function potential_density(Sₐ::Raster, Θ::Raster, p::Float64, rs_dims::Tuple, find_nm::Raster)
-Compute potential density at reference pressure `p`, `σₚ`, using `gsw_rho`  from GibbsSeaWater.jl.
-This conversion depends on absolute salinity (`Sₐ`), conservative temperature (`Θ`) and a
-user entered reference pressure (`p`).
+    function potential_density(Sₐ::Raster, Θ::Raster, p::Float64, find_nm::Raster)
+Compute potential density at reference pressure `p`, `σₚ`, using `gsw_rho`
+from GibbsSeaWater.jl. This computation depends on absolute salinity (`Sₐ`),
+conservative temperature (`Θ`) and a user entered reference pressure (`p`).
 """
-function potential_density(Sₐ::Raster, Θ::Raster, p::Number, rs_dims::Tuple, find_nm::Raster)
+function potential_density(Sₐ::Raster, Θ::Raster, p::Number, find_nm::Raster)
 
-    lons, lats, z, time = rs_dims
-    σₚ = similar(Array(Θ))
+    rs_dims = dims(Sₐ)
+    σₚ = similar(Array(Sₐ))
 
     if isnothing(time)
 
@@ -237,15 +237,16 @@ Compute and return the potential density `σₚ` at reference pressure `p` from 
 conservative temperature `Θ` and a reference pressure `p`. The variable names must be
 passed into the function as a `NamedTuple` in the form
 `(Sₐ = :salt_var, Θ = :temp_var, p = ref_pressure)`. Note `p` in this case is a number.
+The returned `Raster` will have the same dimensions as `Rasterstack` that is passed in.
 """
 potential_density(stack::RasterStack, var_names::NamedTuple) =
     potential_density(stack[var_names.Sₐ], stack[var_names.Θ], var_names.p,
-                      get_dims(stack[var_names.Sₐ]),
                       .!ismissing.(stack[var_names.Sₐ]) .&& .!ismissing.(stack[var_names.Θ]))
 potential_density(series::RasterSeries, var_names::NamedTuple) = potential_density.(series, Ref(var_names))
 """
     function get_dims(raster::Raster)
-Get the dimensions of a `Raster`.
+    function get_dims(stack::RasterStack)
+Get the dimensions of a `Raster` or `RasterStack`.
 """
 function get_dims(raster::Raster)
 


### PR DESCRIPTION
This PR adds a docs badge, adds docstrings for all exported functions and changes the way the dimensions are handled for computed (ie density) variables.