### PR TITLE
Add histogram fitting for `Raster` data structures and break code into submodules

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -19,7 +19,6 @@ jobs:
       matrix:
         version:
           - '1.8'
-          - 'nightly'
         os:
           - ubuntu-latest
         arch:

--- a/Project.toml
+++ b/Project.toml
@@ -6,13 +6,14 @@ version = "0.2.2"
 [deps]
 DimensionalData = "0703355e-b756-11e9-17c0-8b28908087d0"
 GibbsSeaWater = "9a22fb26-0b63-4589-b28e-8f9d0b5c3d05"
+MakieCore = "20f20a25-4f0e-4fdf-b5d1-57303727442b"
 Rasters = "a3a2b9e3-a471-40c9-b274-f788e487c689"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 
 [compat]
+DimensionalData = "=0.24.7"
 GibbsSeaWater = "^0.1.2"
 Rasters = "^0.5.0"
-DimensionalData = "=0.24.7"
 julia = "1.6"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -6,6 +6,7 @@ version = "0.2.2"
 [deps]
 DimensionalData = "0703355e-b756-11e9-17c0-8b28908087d0"
 GibbsSeaWater = "9a22fb26-0b63-4589-b28e-8f9d0b5c3d05"
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 MakieCore = "20f20a25-4f0e-4fdf-b5d1-57303727442b"
 Rasters = "a3a2b9e3-a471-40c9-b274-f788e487c689"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"

--- a/Project.toml
+++ b/Project.toml
@@ -11,6 +11,7 @@ StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 [compat]
 GibbsSeaWater = "^0.1.2"
 Rasters = "^0.5.0"
+DimensionalData = "0.24.7"
 julia = "1.6"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -8,6 +8,7 @@ DimensionalData = "0703355e-b756-11e9-17c0-8b28908087d0"
 GibbsSeaWater = "9a22fb26-0b63-4589-b28e-8f9d0b5c3d05"
 MakieCore = "20f20a25-4f0e-4fdf-b5d1-57303727442b"
 Rasters = "a3a2b9e3-a471-40c9-b274-f788e487c689"
+Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 
 [compat]

--- a/Project.toml
+++ b/Project.toml
@@ -6,11 +6,12 @@ version = "0.2.2"
 [deps]
 GibbsSeaWater = "9a22fb26-0b63-4589-b28e-8f9d0b5c3d05"
 Rasters = "a3a2b9e3-a471-40c9-b274-f788e487c689"
+StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 
 [compat]
-julia = "1.6"
-Rasters = "^0.5.0"
 GibbsSeaWater = "^0.1.2"
+Rasters = "^0.5.0"
+julia = "1.6"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ authors = ["Josef I. Bisits <jbisits@gmail.com>"]
 version = "0.2.2"
 
 [deps]
+DimensionalData = "0703355e-b756-11e9-17c0-8b28908087d0"
 GibbsSeaWater = "9a22fb26-0b63-4589-b28e-8f9d0b5c3d05"
 Rasters = "a3a2b9e3-a471-40c9-b274-f788e487c689"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
@@ -11,7 +12,7 @@ StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 [compat]
 GibbsSeaWater = "^0.1.2"
 Rasters = "^0.5.0"
-DimensionalData = "0.24.7"
+DimensionalData = "=0.24.7"
 julia = "1.6"
 
 [extras]

--- a/src/OceanRasterConversions.jl
+++ b/src/OceanRasterConversions.jl
@@ -1,13 +1,11 @@
 module OceanRasterConversions
 
-using Rasters, GibbsSeaWater
+using Reexport
 
-export
-    convert_ocean_vars,
-    depth_to_pressure, Sₚ_to_Sₐ, θ_to_Θ,
-    get_ρ, get_σₚ, get_α, get_β
-
-include("oceanconversions.jl")
+include("oceanvariableconversions.jl")
 include("oceanvariabledistributions.jl")
+
+@reexport using OceanRasterConversions.OceanVariableConversions
+@reexport using OceanRasterConversions.RasterHistograms
 
 end #module

--- a/src/OceanRasterConversions.jl
+++ b/src/OceanRasterConversions.jl
@@ -1,12 +1,16 @@
 module OceanRasterConversions
 
-using Rasters, GibbsSeaWater
+using Rasters, GibbsSeaWater, StatsBase
+import StatsBase.fit
 
 export
     convert_ocean_vars,
     depth_to_pressure, Sₚ_to_Sₐ, θ_to_Θ,
     get_ρ, get_σₚ, get_α, get_β
 
+export area_weights, volume_weights
+
 include("oceanconversions.jl")
+include("oceanvariabledistributions.jl")
 
 end #module

--- a/src/OceanRasterConversions.jl
+++ b/src/OceanRasterConversions.jl
@@ -8,7 +8,7 @@ export
     depth_to_pressure, Sₚ_to_Sₐ, θ_to_Θ,
     get_ρ, get_σₚ, get_α, get_β
 
-export area_weights, volume_weights
+export single_variable_weights, area_weights, volume_weights
 
 include("oceanconversions.jl")
 include("oceanvariabledistributions.jl")

--- a/src/OceanRasterConversions.jl
+++ b/src/OceanRasterConversions.jl
@@ -1,14 +1,11 @@
 module OceanRasterConversions
 
-using Rasters, GibbsSeaWater, StatsBase
-import StatsBase.fit
+using Rasters, GibbsSeaWater
 
 export
     convert_ocean_vars,
     depth_to_pressure, Sₚ_to_Sₐ, θ_to_Θ,
     get_ρ, get_σₚ, get_α, get_β
-
-export single_variable_weights, area_weights, volume_weights
 
 include("oceanconversions.jl")
 include("oceanvariabledistributions.jl")

--- a/src/oceanvariableconversions.jl
+++ b/src/oceanvariableconversions.jl
@@ -1,3 +1,12 @@
+module OceanVariableConversions
+
+using Rasters, GibbsSeaWater
+
+export
+    convert_ocean_vars,
+    depth_to_pressure, Sₚ_to_Sₐ, θ_to_Θ,
+    get_ρ, get_σₚ, get_α, get_β
+
 """
     function convert_ocean_vars(raster::RasterStack, var_names::NamedTuple;
                                 ref_pressure = nothing,
@@ -340,3 +349,5 @@ function get_dims(raster::Raster)
     return rs_dims
 
 end
+
+end #module

--- a/src/oceanvariabledistributions.jl
+++ b/src/oceanvariabledistributions.jl
@@ -1,6 +1,7 @@
 module RasterHistograms
 
 using Rasters, StatsBase, MakieCore
+using LinearAlgebra: normalize
 import MakieCore.convert_arguments
 import DimensionalData.dim2key
 import Base.show

--- a/src/oceanvariabledistributions.jl
+++ b/src/oceanvariabledistributions.jl
@@ -1,0 +1,111 @@
+#=
+Extend `StatsBase.fit` to accept a `Raster`, an `NTuple` of `Rasters` a `RasterStack` or a
+`RasterSeries` as inputs and produce an N-dimensional `Histogram`.
+Note that for a `RasterStack` the variables that the `Histogram` is to be produced from need
+to be passed in as `Symbol`s contained in a `Tuple`.
+=#
+StatsBase.fit(::Type{Histogram}, rs::Raster, args...; kwargs...) =
+    StatsBase.fit(Histogram, collect(skipmissing(reshape(read(rs), :)[:])), args...;
+                  kwargs...)
+function StatsBase.fit(::Type{Histogram}, rs::NTuple{N, Raster}, args...; kwargs...) where{N}
+
+    find_nm = @. !ismissing(rs[1]) && !ismissing(rs[2])
+    rs_tuple = Tuple(collect(skipmissing(r[find_nm])) for r ∈ rs)
+
+    return StatsBase.fit(Histogram, rs_tuple, args...; kwargs...)
+
+end
+function StatsBase.fit(::Type{Histogram}, stack::RasterStack, vars::Tuple{N, Symbol},
+                       args...; kwargs...) where{N}
+
+    rs_tuple = Tuple(stack[var] for var ∈ vars)
+
+    return StatsBase.fit(Histogram, rs_tuple, args...; kwargs...)
+
+end
+function StatsBase.fit(::Type{Histogram}, series::RasterSeries, vars::Tuple{N, Symbol},
+                       args...; kwargs...) where{N}
+
+    rs_tuple = Tuple(series[1][var] for var ∈ vars)
+    merged_hist = fit(Histogram, rs_tuple, args...; kwargs...)
+    for stack ∈ series[2:end]
+        rs_tuple = Tuple(stack[var] for var ∈ vars)
+        merge!(merged_hist, fit(Histogram, rs_tuple, args...; kwargs...))
+    end
+
+    return merged_hist
+
+end
+"""
+    function area_weights(rs::Union{Raster, RasterStack}; equator_one_degree = 111e3)
+Return the `Weights` for a `Histogram` calculated from the area of each grid cell in a
+`Raster` or `RasterStack`. The `Raster` or `RasterStack` must first be sliced over the
+dimensions one wishes to look at, e.g. for area weights at sea surface the function need
+`rs[Z(1)]` to be passed in. If the original `Raster` only has two spatial dimensions then
+this step may be skipped.
+The keyword argument `equator_one_degree` is one degree at the equator in metres.
+The function returns a container `Weights` so can be passed straight into
+the `fit(::Histogram)` function.
+"""
+function area_weights(rs::Union{Raster, RasterStack}; equator_one_degree = 111e3)
+
+    rs = typeof(rs) <: RasterStack ? rs[keys(rs)[1]] : rs
+
+    dA =if !hasdim(rs, :Z)
+            lon, lat = lookup(rs, X), lookup(rs, Y)
+            lon_model_resolution = unique(diff(lon))[1]
+            lat_model_resolution = unique(diff(lat))[1]
+            dx = (equator_one_degree * lon_model_resolution) .* ones(length(lon))
+            dy = (equator_one_degree * lat_model_resolution) .* cos.(deg2rad.(lat))
+            dx * dy'
+        elseif !hasdim(rs, :Y)
+            lon, z = lookup(rs, X), lookup(rs, Z)
+            lon_model_resolution = unique(diff(lon))[1]
+            dx = (equator_one_degree * lon_model_resolution) .* ones(length(lon))
+            dz = diff(abs.(z))
+            dz = vcat(dz[1], dz)
+            dx * dz'
+        elseif !hasdim(rs, :X)
+            lat, z = lookup(rs, Y), lookup(rs, Z)
+            lat_model_resolution = unique(diff(lat))[1]
+            dy = (equator_one_degree * lat_model_resolution) .* cos.(deg2rad.(lat))
+            dz = diff(abs.(z))
+            dz = vcat(dz[1], dz)
+            dy * dz'
+        end
+    find_nm = reshape(.!ismissing.(rs), :)[:]
+    dA_vec = reshape(dA, :)[find_nm]
+
+    return weights(dA_vec)
+
+end
+"""
+    function volume_weights(rs::Union{Raster, RasterStack}; equator_one_degree = 111e3)
+Return the `Weights` for a `Histogram` calculated from the volume of each grid cell in a
+`Raster` or `RasterStack`. The model resolution is inferred from the `X` and `Y` dimensions
+of the `Raster` or `RasterStack` and assumes that along the `X` and `Y` the resolution is
+unique (though it can be different for `X` and `Y`).
+The keyword argument `equator_one_degree` is one degree at the
+equator in metres. The function returns a container `Weights` so can be passed straight into
+the `fit(::Histogram)` function.
+"""
+function volume_weights(rs::Union{Raster, RasterStack}; equator_one_degree = 111e3)
+
+    rs = typeof(rs) <: RasterStack ? rs[keys(rs)[1]] : rs
+    lon, lat, z = lookup(rs, X), lookup(rs, Y), lookup(rs, Z)
+    lon_model_resolution = unique(diff(lon))[1]
+    lat_model_resolution = unique(diff(lat))[1]
+    dx = (equator_one_degree * lon_model_resolution) .* ones(length(lon))
+    dy = (equator_one_degree * lat_model_resolution) .* cos.(deg2rad.(lat))
+    dz = diff(abs.(z))
+    dz = vcat(dz[1], dz)
+    dV = Array{Float64}(undef, length(dx), length(dy), length(dz))
+    for i ∈ axes(dV, 3)
+        dV[:, :, i] = (dx .* dy') * dz[i]
+    end
+    find_nm = reshape(.!ismissing.(rs), :)[:]
+    dV_vec = reshape(dV, :)[find_nm]
+
+    return weights(dV_vec)
+
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -88,25 +88,24 @@ end
 
 end
 
+using OceanRasterConversions.RasterHistograms
 include("test_oceanvariabledistributions.jl")
 
 @testset "Histograms" begin
 
     for hf ∈ hist_fields
-        @test getproperty(raster_hist, hf) == getproperty(raster_array_hist, hf)
-        @test getproperty(stack_hist, hf)  == getproperty(stack_array_hist, hf)
-        @test getproperty(series_hist, hf) == getproperty(series_array_hist, hf)
+        @test getproperty(raster_hist.histogram, hf) == getproperty(raster_array_hist, hf)
+        @test getproperty(stack_hist.histogram, hf)  == getproperty(stack_array_hist, hf)
+        @test getproperty(series_hist.histogram, hf) == getproperty(series_array_hist, hf)
     end
 
 end
 
-@testset "Weight functions" begin
+# @testset "Weight functions" begin
 
-    @test test_weights_single[find_nm_rs_stack] ==
-            single_variable_weights(rs_stack[:Sₚ], test_weights_single)
-    @test dA_xy_test == area_weights(rs_stack[Z(1)])
-    @test dA_xz_test == area_weights(rs_stack[Y(1)])
-    @test dA_yz_test == area_weights(rs_stack[X(1)])
-    @test dV_test == volume_weights(rs_stack)
+#     @test dA_xy_test == area_weights(rs_stack[Z(1)])
+#     @test dA_xz_test == area_weights(rs_stack[Y(1)])
+#     @test dA_yz_test == area_weights(rs_stack[X(1)])
+#     @test dV_test == volume_weights(rs_stack)
 
-end
+# end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,4 @@
-using OceanRasterConversions, Test, Rasters, GibbsSeaWater
+using OceanRasterConversions, Test, Rasters, GibbsSeaWater, StatsBase
 
 include("test_oceanrasterconversions.jl")
 
@@ -85,5 +85,15 @@ end
     @test_throws ArgumentError convert_ocean_vars(rs_stack_NoX, (Sₚ = :Sₚ, θ = :θ))
     @test_throws ArgumentError convert_ocean_vars(rs_stack_NoY, (Sₚ = :Sₚ, θ = :θ))
     @test_throws ArgumentError convert_ocean_vars(rs_stack_NoZ, (Sₚ = :Sₚ, θ = :θ))
+
+end
+
+include("test_oceanvariabledistributions.jl")
+
+@testset "Histograms" begin
+
+    for hf ∈ hist_fields
+        @test getproperty(raster_hist, hf) == getproperty(array_hist, hf)
+    end
 
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -55,11 +55,11 @@ end
     @test isequal(converted_Sₚ_series, Sₐ_)
     ## `θ_to_Θ`
     @test isequal(converted_θ_series, Θ)
-     ## `get_ρ`
-     @test isequal(converted_ρ_series, ρ)
-     ## `get_σₚ`
-     @test isequal(converted_σₚ_series, σₚ)
-     ## `get_α`
+    ## `get_ρ`
+    @test isequal(converted_ρ_series, ρ)
+    ## `get_σₚ`
+    @test isequal(converted_σₚ_series, σₚ)
+    ## `get_α`
     @test isequal(converted_α_series, α)
     ## `get_β`
     @test isequal(converted_β_series, β)
@@ -94,6 +94,7 @@ include("test_oceanvariabledistributions.jl")
 
     for hf ∈ hist_fields
         @test getproperty(raster_hist, hf) == getproperty(raster_array_hist, hf)
+        @test getproperty(stack_hist, hf)  == getproperty(stack_array_hist, hf)
         @test getproperty(series_hist, hf) == getproperty(series_array_hist, hf)
     end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -91,21 +91,52 @@ end
 using OceanRasterConversions.RasterHistograms
 include("test_oceanvariabledistributions.jl")
 
-@testset "Histograms" begin
+@testset "RasterLayerHistogram" begin
 
-    for hf ∈ hist_fields
-        @test getproperty(raster_hist.histogram, hf) == getproperty(raster_array_hist, hf)
-        @test getproperty(stack_hist.histogram, hf)  == getproperty(stack_array_hist, hf)
-        @test getproperty(series_hist.histogram, hf) == getproperty(series_array_hist, hf)
+    for i ∈ eachindex(RLH)
+        for hf ∈ hist_fields
+            @test getproperty(RLH[i].histogram, hf) == getproperty(raster_array_hists[i], hf)
+        end
     end
 
 end
 
-# @testset "Weight functions" begin
+@testset "RasterStackHistogram" begin
 
-#     @test dA_xy_test == area_weights(rs_stack[Z(1)])
-#     @test dA_xz_test == area_weights(rs_stack[Y(1)])
-#     @test dA_yz_test == area_weights(rs_stack[X(1)])
-#     @test dV_test == volume_weights(rs_stack)
+    for i ∈ eachindex(RSH)
+        for hf ∈ hist_fields
+            @test getproperty(RSH[i].histogram, hf)  == getproperty(stack_array_hists[i], hf)
+        end
+    end
 
-# end
+end
+
+@testset "RasterSeriesHistogram" begin
+
+    for i ∈ eachindex(RSEH)
+        for hf ∈ hist_fields
+            if hf == :weights
+                #Floating point errors appear so use approx for weights
+                @test getproperty(RSEH[i].histogram, hf) ≈ getproperty(series_array_hists[i], hf)
+            else
+                @test getproperty(RSEH[i].histogram, hf) == getproperty(series_array_hists[i], hf)
+            end
+        end
+    end
+
+end
+
+@testset "Weight functions" begin
+
+    @test dA_XY == area_weights(rs_stack[Z(1)]).values
+    @test dA_XZ == area_weights(rs_stack[Y(1)]).values
+    @test dA_YZ == area_weights(rs_stack[X(1)]).values
+    @test dV == volume_weights(rs_stack).values
+
+end
+
+@testset "Not exported functions" begin
+
+    @test RasterHistograms.find_stack_non_missing(rs_stack) == find_nm_stack
+
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -93,7 +93,19 @@ include("test_oceanvariabledistributions.jl")
 @testset "Histograms" begin
 
     for hf ∈ hist_fields
-        @test getproperty(raster_hist, hf) == getproperty(array_hist, hf)
+        @test getproperty(raster_hist, hf) == getproperty(raster_array_hist, hf)
+        @test getproperty(series_hist, hf) == getproperty(series_array_hist, hf)
     end
+
+end
+
+@testset "Weight functions" begin
+
+    @test test_weights_single[find_nm_rs_stack] ==
+            single_variable_weights(rs_stack[:Sₚ], test_weights_single)
+    @test dA_xy_test == area_weights(rs_stack[Z(1)])
+    @test dA_xz_test == area_weights(rs_stack[Y(1)])
+    @test dA_yz_test == area_weights(rs_stack[X(1)])
+    @test dV_test == volume_weights(rs_stack)
 
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -88,7 +88,6 @@ end
 
 end
 
-using OceanRasterConversions.RasterHistograms
 include("test_oceanvariabledistributions.jl")
 
 @testset "RasterLayerHistogram" begin

--- a/test/test_oceanvariabledistributions.jl
+++ b/test/test_oceanvariabledistributions.jl
@@ -1,7 +1,10 @@
-# I think I can test nearly all my `fit` methods with a `RasterSeries`
+# Single `Raster`
+raster_hist = fit(Histogram, rs_stack[:Sₚ])
+raster_array_hist = fit(Histogram, collect(skipmissing(reshape(rs_stack[:Sₚ], :))))
 
+# `RasterSeries` which uses all other methods so should cover code
 test_hist_bins = (33:0.025:38, -2:0.1:20)
-raster_hist = fit(Histogram, rs_series, (:Sₚ, :θ), test_hist_bins)
+series_hist = fit(Histogram, rs_series, (:Sₚ, :θ), test_hist_bins)
 
 # extract all data and compare `rs_hist` to `Histogram` from an `NTuple` of `Array`s
 Sₚ_vec = Float64[]
@@ -12,6 +15,33 @@ for r ∈ rs_series
     append!(θ_vec, collect(skipmissing(r[:θ][find_nm])))
 end
 
-array_hist = fit(Histogram, (Sₚ_vec, θ_vec), test_hist_bins)
+series_array_hist = fit(Histogram, (Sₚ_vec, θ_vec), test_hist_bins)
 
 hist_fields = (:closed, :edges, :isdensity, :weights)
+
+# Weight functions
+
+test_weights_single = randn(length(reshape(rs_stack[:Sₚ], :)))
+single_var_weights = single_variable_weights(rs_stack[:Sₚ], test_weights_single)
+find_nm_rs_stack = @. !ismissing(rs_stack[:Sₚ])
+find_nm_xy = reshape(find_nm_rs_stack[Z(1)], :)
+find_nm_xz = reshape(find_nm_rs_stack[Y(1)], :)
+find_nm_yz = reshape(find_nm_rs_stack[X(1)], :)
+find_nm_rs_stack = reshape(find_nm_rs_stack, :)
+
+lo, la, z, ti = lookup(rs_stack, X), lookup(rs_stack, Y), lookup(rs_stack, Z), lookup(rs_stack, Ti)
+dx = (111e3 * (lo[2] - lo[1])) .* ones(length(lo))
+dy = (111e3 * (la[2] - la[1])) .* cos.(deg2rad.(la))
+dz = fill(abs(z[2]-z[1]), length(z))
+# XY area
+dA_xy = repeat(reshape(dx .* dy', :), outer = length(ti))
+dA_xy_test = dA_xy[find_nm_xy]
+# XZ area
+dA_xz = repeat(reshape(dx .* dz', :), outer = length(ti))
+dA_xz_test = dA_xz[find_nm_xz]
+# YZ area
+dA_yz = repeat(reshape(dy .* dz', :), outer = length(ti))
+dA_yz_test = dA_yz[find_nm_yz]
+# Volume
+dV = repeat(dz[1] * reshape(dx .* dy', :), outer = length(z) * length(ti))
+dV_test = dV[find_nm_rs_stack]

--- a/test/test_oceanvariabledistributions.jl
+++ b/test/test_oceanvariabledistributions.jl
@@ -1,0 +1,21 @@
+# I think I can test nearly all my `fit` methods with a `RasterSeries`
+
+test_hist_bins = (33:0.025:38, -2:0.1:20)
+raster_hist = fit(Histogram, rs_series, (:Sₚ, :θ), test_hist_bins)
+
+# extract all data and compare `rs_hist` to `Histogram` from an `NTuple` of `Array`s
+Sₚ_vec = Float64[]
+θ_vec = Float64[]
+for r ∈ rs_series
+    find_nm = @. !ismissing(r[:Sₚ]) && !ismissing(r[:θ])
+    append!(Sₚ_vec, collect(skipmissing(r[:Sₚ][find_nm])))
+    append!(θ_vec, collect(skipmissing(r[:θ][find_nm])))
+end
+
+array_hist = fit(Histogram, (Sₚ_vec, θ_vec), test_hist_bins)
+
+hist_fields = (:closed, :edges, :isdensity, :weights)
+for hf ∈ hist_fields
+    println(getproperty(raster_hist, hf))
+    #println(array_hist.$(hf))
+end

--- a/test/test_oceanvariabledistributions.jl
+++ b/test/test_oceanvariabledistributions.jl
@@ -1,58 +1,102 @@
+# test values
+test_hist_edges = (33:0.025:38, -2:0.1:20)
+test_hist_weights = weights(randn(size(rs_stack[:Sₚ])))
+test_nbins = 200
+
 # Single `Raster`
+# RasterLayerHistograma
 raster_hist = RasterLayerHistogram(rs_stack[:Sₚ])
+raster_hist_nb = RasterLayerHistogram(rs_stack[:Sₚ]; nbins = test_nbins)
+raster_hist_w = RasterLayerHistogram(rs_stack[:Sₚ], test_hist_weights)
+raster_hist_wnb = RasterLayerHistogram(rs_stack[:Sₚ], test_hist_weights; nbins = test_nbins)
+raster_hist_e = RasterLayerHistogram(rs_stack[:Sₚ], test_hist_edges[1])
+raster_hist_we = RasterLayerHistogram(rs_stack[:Sₚ], test_hist_weights, test_hist_edges[1])
+RLH = (raster_hist, raster_hist_nb, raster_hist_w, raster_hist_wnb,
+       raster_hist_e, raster_hist_we)
+# fitted histograms
+find_nm_rs = @. !ismissing(rs_stack[:Sₚ])
+find_nm_rs_vec = reshape(find_nm_rs, :)
 raster_array_hist = fit(Histogram, collect(skipmissing(reshape(rs_stack[:Sₚ], :))))
+raster_array_hist_nb = fit(Histogram, collect(skipmissing(reshape(rs_stack[:Sₚ], :)));
+                           nbins = test_nbins)
+raster_array_hist_w = fit(Histogram, collect(skipmissing(reshape(rs_stack[:Sₚ], :))),
+                          test_hist_weights[find_nm_rs_vec])
+raster_array_hist_wnb = fit(Histogram, collect(skipmissing(reshape(rs_stack[:Sₚ], :))),
+                            test_hist_weights[find_nm_rs_vec]; nbins = test_nbins)
+raster_array_hist_e = fit(Histogram, collect(skipmissing(reshape(rs_stack[:Sₚ], :))),
+                          test_hist_edges[1])
+raster_array_hist_we = fit(Histogram, collect(skipmissing(reshape(rs_stack[:Sₚ], :))),
+                          test_hist_weights[find_nm_rs_vec], test_hist_edges[1] )
+raster_array_hists = (raster_array_hist, raster_array_hist_nb, raster_array_hist_w,
+                      raster_array_hist_wnb, raster_array_hist_e, raster_array_hist_we)
 
 # `RasterStack`
 stack_hist = RasterStackHistogram(rs_stack)
+stack_hist_nb = RasterStackHistogram(rs_stack; nbins = test_nbins)
+stack_hist_w = RasterStackHistogram(rs_stack, test_hist_weights)
+stack_hist_wnb = RasterStackHistogram(rs_stack, test_hist_weights; nbins = test_nbins)
+stack_hist_e = RasterStackHistogram(rs_stack, test_hist_edges)
+stack_hist_we = RasterStackHistogram(rs_stack, test_hist_weights, test_hist_edges)
+RSH = (stack_hist, stack_hist_nb, stack_hist_w, stack_hist_wnb, stack_hist_e, stack_hist_we)
+
 find_nm_stack = @. !ismissing(rs_stack[:Sₚ]) && !ismissing(rs_stack[:θ])
+find_nm_stack_vec = reshape(find_nm_stack, :)
 Sₚ_vec = collect(skipmissing(rs_stack[:Sₚ][find_nm_stack]))
 θ_vec = collect(skipmissing(rs_stack[:θ][find_nm_stack]))
 stack_array_hist = fit(Histogram, (Sₚ_vec, θ_vec))
+stack_array_hist_nb = fit(Histogram, (Sₚ_vec, θ_vec); nbins = test_nbins)
+stack_array_hist_w = fit(Histogram, (Sₚ_vec, θ_vec), test_hist_weights[find_nm_stack_vec])
+stack_array_hist_wnb = fit(Histogram, (Sₚ_vec, θ_vec), test_hist_weights[find_nm_stack_vec];
+                           nbins = test_nbins)
+stack_array_hist_e = fit(Histogram, (Sₚ_vec, θ_vec), test_hist_edges)
+stack_array_hist_we = fit(Histogram, (Sₚ_vec, θ_vec), test_hist_weights[find_nm_stack_vec],
+                          test_hist_edges)
+stack_array_hists = (stack_array_hist, stack_array_hist_nb, stack_array_hist_w,
+                     stack_array_hist_wnb, stack_array_hist_e, stack_array_hist_we)
 
 # `RasterSeries`
-test_hist_bins = (33:0.025:38, -2:0.1:20)
-series_hist = RasterSeriesHistogram(rs_series, test_hist_bins)
-
+test_hist_weights_series = randn(size(rs_series[1]))
+series_hist_e = RasterSeriesHistogram(rs_series, test_hist_edges)
+series_hist_we = RasterSeriesHistogram(rs_series, weights(test_hist_weights_series), test_hist_edges)
+RSEH = (series_hist_e, series_hist_we)
 # extract all data and compare `rs_hist` to `Histogram` from an `NTuple` of `Array`s
 Sₚ_vec = Float64[]
 θ_vec = Float64[]
+test_series_weights = Float64[]
 for r ∈ rs_series
     find_nm = @. !ismissing(r[:Sₚ]) && !ismissing(r[:θ])
+    append!(test_series_weights, test_hist_weights_series[reshape(find_nm, :)])
     append!(Sₚ_vec, collect(skipmissing(r[:Sₚ][find_nm])))
     append!(θ_vec, collect(skipmissing(r[:θ][find_nm])))
 end
+series_array_hist_e = fit(Histogram, (Sₚ_vec, θ_vec), test_hist_edges)
+series_array_hist_we = fit(Histogram, (Sₚ_vec, θ_vec), weights(test_series_weights),
+                           test_hist_edges)
+series_array_hists = (series_array_hist_e, series_array_hist_we)
 
-series_array_hist = fit(Histogram, (Sₚ_vec, θ_vec), test_hist_bins)
 
+findall(RSEH[2].histogram.weights .!== series_array_hists[2].weights)
+RSEH[2].histogram.weights[1, 1] ≈ series_array_hists[2].weights[1, 1]
 hist_fields = (:closed, :edges, :isdensity, :weights)
 
 # Weight functions
-
-find_nm_rs_stack = @. !ismissing(rs_stack[:Sₚ])
-find_nm_xy = reshape(find_nm_rs_stack[Z(1)], :)
-find_nm_xz = reshape(find_nm_rs_stack[Y(1)], :)
-find_nm_yz = reshape(find_nm_rs_stack[X(1)], :)
-find_nm_rs_stack = reshape(find_nm_rs_stack, :)
 
 lo, la, z, ti = lookup(rs_stack, X), lookup(rs_stack, Y), lookup(rs_stack, Z), lookup(rs_stack, Ti)
 dx = (111e3 * (lo[2] - lo[1])) .* ones(length(lo))
 dy = (111e3 * (la[2] - la[1])) .* cos.(deg2rad.(la))
 dz = fill(abs(z[2]-z[1]), length(z))
 # XY area
-dA_xy = repeat(reshape(dx .* dy', :), outer = length(ti))
-dA_xy_test = dA_xy[find_nm_xy]
+dA_XY = repeat(reshape(dx .* dy', :), outer = length(ti))
 # XZ area
-dA_xz = repeat(reshape(dx .* dz', :), outer = length(ti))
-dA_xz_test = dA_xz[find_nm_xz]
+dA_XZ = repeat(reshape(dx .* dz', :), outer = length(ti))
 # YZ area
-dA_yz = repeat(reshape(dy .* dz', :), outer = length(ti))
-dA_yz_test = dA_yz[find_nm_yz]
+dA_YZ = repeat(reshape(dy .* dz', :), outer = length(ti))
 # Volume
 dV = repeat(dz[1] * reshape(dx .* dy', :), outer = length(z) * length(ti))
-dV_test = dV[find_nm_rs_stack]
 
 ## New method
 # using OceanRasterConversions.RasterHistograms
 # RasterLayerHistogram(rs_stack[:Sₚ])
-# RasterStackHistogram(rs_stack)
-# RasterSeriesHistogram(rs_series, (33:0.01:38, -2:0.1:20))
+# test = RasterStackHistogram(rs_stack)
+# test = RasterSeriesHistogram(rs_series, (33:0.01:38, -2:0.1:20))
+# RasterHistograms.find_stack_non_missing(rs_stack)

--- a/test/test_oceanvariabledistributions.jl
+++ b/test/test_oceanvariabledistributions.jl
@@ -1,9 +1,9 @@
 # Single `Raster`
-raster_hist = fit(Histogram, rs_stack[:Sₚ])
+raster_hist = RasterLayerHistogram(rs_stack[:Sₚ])
 raster_array_hist = fit(Histogram, collect(skipmissing(reshape(rs_stack[:Sₚ], :))))
 
 # `RasterStack`
-stack_hist = fit(Histogram, rs_stack, (:Sₚ, :θ))
+stack_hist = RasterStackHistogram(rs_stack)
 find_nm_stack = @. !ismissing(rs_stack[:Sₚ]) && !ismissing(rs_stack[:θ])
 Sₚ_vec = collect(skipmissing(rs_stack[:Sₚ][find_nm_stack]))
 θ_vec = collect(skipmissing(rs_stack[:θ][find_nm_stack]))
@@ -11,7 +11,7 @@ stack_array_hist = fit(Histogram, (Sₚ_vec, θ_vec))
 
 # `RasterSeries`
 test_hist_bins = (33:0.025:38, -2:0.1:20)
-series_hist = fit(Histogram, rs_series, (:Sₚ, :θ), test_hist_bins)
+series_hist = RasterSeriesHistogram(rs_series, test_hist_bins)
 
 # extract all data and compare `rs_hist` to `Histogram` from an `NTuple` of `Array`s
 Sₚ_vec = Float64[]
@@ -28,8 +28,6 @@ hist_fields = (:closed, :edges, :isdensity, :weights)
 
 # Weight functions
 
-test_weights_single = randn(length(reshape(rs_stack[:Sₚ], :)))
-single_var_weights = single_variable_weights(rs_stack[:Sₚ], test_weights_single)
 find_nm_rs_stack = @. !ismissing(rs_stack[:Sₚ])
 find_nm_xy = reshape(find_nm_rs_stack[Z(1)], :)
 find_nm_xz = reshape(find_nm_rs_stack[Y(1)], :)
@@ -52,3 +50,9 @@ dA_yz_test = dA_yz[find_nm_yz]
 # Volume
 dV = repeat(dz[1] * reshape(dx .* dy', :), outer = length(z) * length(ti))
 dV_test = dV[find_nm_rs_stack]
+
+## New method
+# using OceanRasterConversions.RasterHistograms
+# RasterLayerHistogram(rs_stack[:Sₚ])
+# RasterStackHistogram(rs_stack)
+# RasterSeriesHistogram(rs_series, (33:0.01:38, -2:0.1:20))

--- a/test/test_oceanvariabledistributions.jl
+++ b/test/test_oceanvariabledistributions.jl
@@ -15,7 +15,3 @@ end
 array_hist = fit(Histogram, (Sₚ_vec, θ_vec), test_hist_bins)
 
 hist_fields = (:closed, :edges, :isdensity, :weights)
-for hf ∈ hist_fields
-    println(getproperty(raster_hist, hf))
-    #println(array_hist.$(hf))
-end

--- a/test/test_oceanvariabledistributions.jl
+++ b/test/test_oceanvariabledistributions.jl
@@ -2,7 +2,14 @@
 raster_hist = fit(Histogram, rs_stack[:Sₚ])
 raster_array_hist = fit(Histogram, collect(skipmissing(reshape(rs_stack[:Sₚ], :))))
 
-# `RasterSeries` which uses all other methods so should cover code
+# `RasterStack`
+stack_hist = fit(Histogram, rs_stack, (:Sₚ, :θ))
+find_nm_stack = @. !ismissing(rs_stack[:Sₚ]) && !ismissing(rs_stack[:θ])
+Sₚ_vec = collect(skipmissing(rs_stack[:Sₚ][find_nm_stack]))
+θ_vec = collect(skipmissing(rs_stack[:θ][find_nm_stack]))
+stack_array_hist = fit(Histogram, (Sₚ_vec, θ_vec))
+
+# `RasterSeries`
 test_hist_bins = (33:0.025:38, -2:0.1:20)
 series_hist = fit(Histogram, rs_series, (:Sₚ, :θ), test_hist_bins)
 

--- a/test/test_oceanvariabledistributions.jl
+++ b/test/test_oceanvariabledistributions.jl
@@ -74,9 +74,6 @@ series_array_hist_we = fit(Histogram, (Sₚ_vec, θ_vec), weights(test_series_we
                            test_hist_edges)
 series_array_hists = (series_array_hist_e, series_array_hist_we)
 
-
-findall(RSEH[2].histogram.weights .!== series_array_hists[2].weights)
-RSEH[2].histogram.weights[1, 1] ≈ series_array_hists[2].weights[1, 1]
 hist_fields = (:closed, :edges, :isdensity, :weights)
 
 # Weight functions
@@ -99,4 +96,3 @@ dV = repeat(dz[1] * reshape(dx .* dy', :), outer = length(z) * length(ti))
 # RasterLayerHistogram(rs_stack[:Sₚ])
 # test = RasterStackHistogram(rs_stack)
 # test = RasterSeriesHistogram(rs_series, (33:0.01:38, -2:0.1:20))
-# RasterHistograms.find_stack_non_missing(rs_stack)


### PR DESCRIPTION
This PR ~~adds methods to `fit` from StatsBase.jl for `Raster`s, `RasterStack`s and `RasterSeries`s~~ creates the new module `RasterHistogras`.  There is an abstract type `AbstracRasterHistogram` and a mutable type for generating a `Histogram` from a `Raster`, `RasterStack`, or `RasterSeries`. The `RasterLayerHistogram` is 1 dimensional while the `RasterStackHistogram` and `RasterSeriesHistogram` can be N-dimensional where N is the number of layers. The types are mutable so that the `Histogram` (that is fit using [StastBase.jl](https://juliastats.org/StatsBase.jl/stable/empirical/)) can be `normalize`d and updated in the `AbstractRasterHistogram`.

There are functions to calculate area and volume weights based on the dimensions of `Raster` source.

The code is also organised into submodules so only parts of the package that are necessary to ones use can be loaded.
Closes #35  