### PR TITLE
Up package version

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "OceanRasterConversions"
 uuid = "07ff2621-03e0-4bfb-9812-e5d28c6dbff8"
 authors = ["Josef I. Bisits <jbisits@gmail.com>"]
-version = "0.3.2"
+version = "0.4.0"
 
 [deps]
 DimensionalData = "0703355e-b756-11e9-17c0-8b28908087d0"
@@ -18,7 +18,7 @@ StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 [compat]
 DimensionalData = "0.24"
 DocStringExtensions = "0.9"
-GibbsSeaWater = "^0.1.2"
+GibbsSeaWater = "0.1"
 MakieCore = "0.6"
 Rasters = "0.6, 0.7, 0.8"
 RecipesBase = "1.3"


### PR DESCRIPTION
With version 8.0 Rasters.jl now uses package extensions which means to read netcdf files NCDatasets.jl must also be loaded.