### PR TITLE
Add `colorscale` argument for Makie.jl plots

### DIFF
--- a/examples/raster_histograms.jl
+++ b/examples/raster_histograms.jl
@@ -77,20 +77,6 @@ show_empty_bins = false
 hm = heatmap!(ax, stack_hist, show_empty_bins; colorscale = log10)
 Colorbar(fig[1, 2], hm)
 fig
-# Currently there is no `log10` colourscale for a `heatmap` in Makie.jl (though it looks
-# like it will be [here soon](https://github.com/MakieOrg/Makie.jl/pull/2493)) so to view
-# the data on a `log10` scale we can extract the data from the `stack_hist.histogram`,
-# transform the weights and then plot
-fig = Figure(size = (500, 500))
-ax = Axis(fig[1, 1];
-          title = "Temperature and salinity joint distribution (unweighted, log10 colourscale)",
-          xlabel = "Practical salinity (psu)",
-          ylabel = "Potential temperature (°C)")
-hm = heatmap!(ax, stack_hist.histogram.edges..., log10.(stack_hist.histogram.weights);
-              colorrange = (0, 5),
-              lowclip = :white)
-Colorbar(fig[1, 2], hm)
-fig
 # ### Weighting the `Histogram`
 # The module also exports simple functions for calculating area and volume weights from the
 # dimensions of the grid and plot the data. Where weights are available from model data they
@@ -103,17 +89,5 @@ ax = Axis(fig[1, 1];
           xlabel = "Practical salinity (psu)",
           ylabel = "Potential temperature (°C)")
 hm = heatmap!(ax, weighted_stack_hist, show_empty_bins; colorscale = log10)
-Colorbar(fig[1, 2], hm)
-fig
-# Again to view on a `log10` scale we extract the data and transform
-fig = Figure(size = (500, 500))
-ax = Axis(fig[1, 1];
-          title = "Temperature and salinity joint distribution (weighted by volume, log10 colourscale)",
-          xlabel = "Practical salinity (psu)",
-          ylabel = "Potential temperature (°C)")
-hm = heatmap!(ax, weighted_stack_hist.histogram.edges...,
-              log10.(weighted_stack_hist.histogram.weights);
-              colorrange = (11, 16),
-              lowclip = :white)
 Colorbar(fig[1, 2], hm)
 fig

--- a/examples/raster_histograms.jl
+++ b/examples/raster_histograms.jl
@@ -74,7 +74,7 @@ ax = Axis(fig[1, 1];
           xlabel = "Practical salinity (psu)",
           ylabel = "Potential temperature (°C)")
 show_empty_bins = false
-hm = heatmap!(ax, stack_hist, show_empty_bins)
+hm = heatmap!(ax, stack_hist, show_empty_bins; colorscale = log10)
 Colorbar(fig[1, 2], hm)
 fig
 # Currently there is no `log10` colourscale for a `heatmap` in Makie.jl (though it looks
@@ -102,7 +102,7 @@ ax = Axis(fig[1, 1];
           title = "Temperature and salinity joint distribution (weighted)",
           xlabel = "Practical salinity (psu)",
           ylabel = "Potential temperature (°C)")
-hm = heatmap!(ax, weighted_stack_hist, show_empty_bins)
+hm = heatmap!(ax, weighted_stack_hist, show_empty_bins; colorscale = log10)
 Colorbar(fig[1, 2], hm)
 fig
 # Again to view on a `log10` scale we extract the data and transform


### PR DESCRIPTION
With Makie.jl 0.19.6 there is the keyword argument `colorscale` for `heatmap`. Hopefully this means the example can be reduced to just one plot rather than having to manually take `log10` of the data.

Closes #53 